### PR TITLE
Add The MASK Coin — Meme + Utility Token on Solana

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -1,12 +1,28 @@
-{
-  "chainId": 101,
-  "address": "HjHgtmRntsg3wU4aED7PfQ6oFq4XbmMrLjmRAkG5LumE",
-  "symbol": "LUSD",
-  "name": "LumE USD",
-  "decimals": 8,
-  "logoURI": "https://gateway.pinata.cloud/ipfs/bafybeifqn76mz2ctuzludo6uv4v5wm76zjc6oinfg7ez2sqpuk5ig6rzaa",
-  "tags": ["stablecoin"],
-  "extensions": {
-    "website": "https://t.me/LumeUSD"
+[
+  {
+    "chainId": 101,
+    "address": "HjHgtmRntsg3wU4aED7PfQ6oFq4XbmMrLjmRAkG5LumE",
+    "symbol": "LUSD",
+    "name": "LumE USD",
+    "decimals": 8,
+    "logoURI": "https://gateway.pinata.cloud/ipfs/...",
+    "tags": ["stablecoin"],
+    "extensions": {
+      "website": "https://t.me/LumeUSD"
+    }
+  },
+  {
+    "chainId": 101,
+    "address": "DK9DNsfvWcHirv9YZ2GcLbKqaGMkQ2JVYFxU7cGhvFhM",
+    "symbol": "MASK",
+    "name": "The MASK Coin",
+    "decimals": 3,
+    "logoURI": "https://amaranth-negative-rat-588.mypinata.cloud/ipfs/bafkreifyglqjzp2bnnhesxdbfme3355sgedeb46qyvbo3chfbt3yrq4ovq",
+    "tags": ["meme", "utility"],
+    "extensions": {
+      "website": "https://www.themaskcoin.com",
+      "twitter": "https://x.com/TheMaskCoinMASK",
+      "telegram": "https://t.me/TheMaskCoinMASK"
+    }
   }
-}
+]


### PR DESCRIPTION
This PR adds The MASK Coin (MASK) to the Solana token list.

- Decimals: 3  
- Logo hosted via IPFS  
- Website: https://www.themaskcoin.com  
- Twitter: https://x.com/TheMaskCoinMASK  
- Telegram: https://t.me/TheMaskCoinMASK